### PR TITLE
Loosen version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/chronicl/typed-sled"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sled = "0.34.6"
-serde = {version = "1.0", features=["derive"]}
-bincode = "1.3.3"
-async-trait = "0.1.51"
+sled = "0.34"
+serde = {version = "1", features=["derive"]}
+bincode = "1"
+async-trait = "0.1"
 
 [features]
 convert = []


### PR DESCRIPTION
Currently the version requirements are quite strict. Since all crates abide by [semver](https://semver.org/) we can safely loosen to major versions. This should ease maintenance