### PR TITLE
adds msg with hint to panics in (de)serialize func

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,14 +566,14 @@ pub fn deserialize<'a, T>(bytes: &'a [u8]) -> T
 where
     T: serde::de::Deserialize<'a>,
 {
-    bincode::deserialize(bytes).unwrap()
+    bincode::deserialize(bytes).expect("deserialization failed, did the type serialized change?")
 }
 
 pub fn serialize<T>(value: &T) -> Vec<u8>
 where
     T: serde::Serialize,
 {
-    bincode::serialize(value).unwrap()
+    bincode::serialize(value).expect("serialization failed, did the type serialized change?")
 }
 
 #[test]


### PR DESCRIPTION
I replaced the `unwrap` in the serialization and deserialization routine with an `expect` call with a message hinting the type serialized might have changed. This means panics there now look like:
```
thread 'main' panicked at 'deserialization failed, did the type serialized change?: Io(Custom { kind: UnexpectedEof, err
or: "" })', /home/david/.cargo/git/checkouts/typed-sled-bd8e5be4b55e613e/88a6cd7/src/lib.rs:596:33
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

A better fix would be to expand the sled `Error` so it includes serialization errors. Though I do not think this is an error that could be handled there is still an advantage to returning an error here. A user unwrapping would then get the line in their code where things go wrong instead of some dependency.